### PR TITLE
Updated chai to version 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-plugin-object-assign": "1.2.1",
     "babelify": "6.3.0",
     "browserify": "10.2.6",
-    "chai": "2.3.0",
+    "chai": "3.3.0",
     "mocha": "2.3.3"
   },
   "dependencies": {


### PR DESCRIPTION
:rocket:

chai just published version 3.3.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 85 commits (ahead by 85, behind by 0).

- [df954cc](https://github.com/chaijs/chai/commit/df954ccacf77cc740f45730c04a37bccf7387456): Merge pull request #516 from keithamus/release-3.2.0
- [13a9009](https://github.com/chaijs/chai/commit/13a90097eb6f59e3b0957ed38a61bcf8c5ff8481): chai@3.3.0
- [cf9f5d9](https://github.com/chaijs/chai/commit/cf9f5d99d7f4dd639573af45c09ef5bf5371d5eb): Merge pull request #512 from dereke/master
- [5044dc0](https://github.com/chaijs/chai/commit/5044dc088e673e4d8a9aa150db0583612fdc21ab): Merge pull request #514 from kpdecker/prop-trace
- [b6b84e5](https://github.com/chaijs/chai/commit/b6b84e56317bc19ed8bd36609155f48c5a1103e8): Fix stack trace tracking for property asserts
- [eaba0be](https://github.com/chaijs/chai/commit/eaba0be444ad9fb953bdefdf012db473f0c4b151): fixed expect('').to.contain('') so it passes
- [a42ac43](https://github.com/chaijs/chai/commit/a42ac436bbb5e2f8a13faf5e572627d902a93fb6): Merge pull request #496 from astorije/astorije/frozen-errors
- [1cc56c8](https://github.com/chaijs/chai/commit/1cc56c88eb06f05dd7571bf789ec616fc3d4b80c): Remove some trailing whitespaces
- [ffc59fc](https://github.com/chaijs/chai/commit/ffc59fccd54432b8ce7ddb158b18df52b3ef2cee): Make sure TypeErrors thrown by extensible are treated in a ES6 way and test these
- [9b71590](https://github.com/chaijs/chai/commit/9b71590fe3c5ed5485eddc3df0f001ad9fbd2ec2): Make sure TypeErrors thrown by sealed are treated in a ES6 way and test these
- [eae67c0](https://github.com/chaijs/chai/commit/eae67c0d5c5f3c0c464d57fc8ffed4963abe8fca): Make sure TypeErrors thrown by frozen are treated in a ES6 way and test these
- [7d36b5a](https://github.com/chaijs/chai/commit/7d36b5aa4ef56c7e95daebf31d0d5dcac91995f3): Merge pull request #500 from wraithan/add-assert-gte-lte
- [8aea7a5](https://github.com/chaijs/chai/commit/8aea7a55df1c41391cc5f4f71133f77ba198d90c): Merge pull request #499 from Daveloper87/empty_string_check_fix
- [3c681e2](https://github.com/chaijs/chai/commit/3c681e2dcedf6cd5958c53a20f881e02c1999c37): isAtLeast, isAtMost assertions added to assert interface
- [bba85d0](https://github.com/chaijs/chai/commit/bba85d0f378be340cf1401ef02dd614fd4fa0244): Simplified .empty


There are 85 commits in total. See the [full diff](https://github.com/chaijs/chai/compare/3de55026458ace296df354757361953ec1949859...df954ccacf77cc740f45730c04a37bccf7387456).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>