### PR TITLE
Updated browserify to version 11.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-core": "5.8.25",
     "babel-plugin-object-assign": "1.2.1",
     "babelify": "6.3.0",
-    "browserify": "10.2.6",
+    "browserify": "11.2.0",
     "chai": "3.3.0",
     "mocha": "2.3.3"
   },


### PR DESCRIPTION
:rocket:

browserify just published version 11.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 26 commits (ahead by 26, behind by 0).

- [b7cf5be](https://github.com/substack/node-browserify/commit/b7cf5bef990a6823d14e2d437e15112aa6b3adfa): 11.2.0
- [bb2a99d](https://github.com/substack/node-browserify/commit/bb2a99dd6cb24899ca82ca898cbe4ab9e7002430): Merge pull request #1361 from substack/fix-bare
- [e781d9d](https://github.com/substack/node-browserify/commit/e781d9da9577c233b35201763bc75111b862b1b8): Merge pull request #1377 from demohi/patch-2
- [05d7861](https://github.com/substack/node-browserify/commit/05d786175e13b873c49afc40170a0428eb56354c): update package.json version
- [85e4b9d](https://github.com/substack/node-browserify/commit/85e4b9daa7a0659b5ad1eecab4eb10193f04ccf9): 11.1.0
- [c1c6b72](https://github.com/substack/node-browserify/commit/c1c6b724ef78b2ea775e43a54625f0f6c1f572e5): browserify adds the '.' in case you forget it
- [97a122e](https://github.com/substack/node-browserify/commit/97a122e9c885158733e0fa2f4eecf5d238202381): Update travis Node.js version & remove io.js
- [cf32d77](https://github.com/substack/node-browserify/commit/cf32d77b28a3a1c429063740842c5d35a6651de0): Exclude "process" and "buffer" when "bundleExternal === false"
- [7487bff](https://github.com/substack/node-browserify/commit/7487bff8f4ae8fc150778b10a91dc4c78233f801): Fix "--bare" and "--igv"
- [f7e626c](https://github.com/substack/node-browserify/commit/f7e626ca75bd925a584f9b0fe8ff9d4b8e90f188): Merge pull request #1338 from jcppman/update-readme
- [34e46a9](https://github.com/substack/node-browserify/commit/34e46a97706f35221dd5654e4240d20c608c1778): 11.0.1
- [90a429d](https://github.com/substack/node-browserify/commit/90a429d6c22eefa61f73840ca212e7784666660a): pipe bundle from output instead of pipeline to ensure that the bundle stream ends
- [9d61b35](https://github.com/substack/node-browserify/commit/9d61b356b94a8faeee0b7a617695bd4fce3c17f3): update a wrong info in readme.markdown
- [59cee86](https://github.com/substack/node-browserify/commit/59cee8675f3e34fae792e83e25db16428e6f7a4f): 11.0.0
- [fad6a22](https://github.com/substack/node-browserify/commit/fad6a22200103ec8c1fd272b519f163ba6edd05c): Merge branch 'stevemao-patch-2'


There are 26 commits in total. See the [full diff](https://github.com/substack/node-browserify/compare/2462712ef368ffd1acbd5914aac7a128ea55defc...b7cf5bef990a6823d14e2d437e15112aa6b3adfa).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>